### PR TITLE
fix(remotes): Tweak fetching to hopefully be more robust.

### DIFF
--- a/_remotes.xml
+++ b/_remotes.xml
@@ -7,6 +7,7 @@
            fetch="https://chromium.googlesource.com/"
            alias="cros" />
   <remote  name="coreos"
-           fetch="https://github.com/"
-           alias="coreos" />
+           fetch=".." />
+  <remote  name="private"
+           fetch="ssh://git@github.com" />
 </manifest>

--- a/full.xml
+++ b/full.xml
@@ -2,7 +2,9 @@
 <manifest>
   <include name="_remotes.xml" />
   <default revision="refs/heads/master"
-           remote="coreos" sync-j="8" />
+           remote="coreos"
+           sync-c="true"
+           sync-j="4" />
   <notice>
 Your sources have been sync'd successfully.
   </notice>


### PR DESCRIPTION
At the moment builtbot keeps having trouble fetching changes from
GitHub. It seems possible that multiple jobs each using 8 threads to
fetch code via HTTPS is triggering some sort of DOS protection, causing
many of our requests to fail. To avoid this here are a few changes taken
from the CyanogenMod project which also uses GitHub:
- Reduce threads to 4 (sync-j)
- Request only the branches specified by the manifest (sync-c)
- Use a relative path for the github remote. This means that all other
  projects will be fetched using the same protocol://hostname that the
  manifest was cloned over. That way we aren't stuck with HTTPS only.
- For funzies add a private GitHub remote that uses ssh. This can be
  useful for adding/overriding projects in local_manifest.xml

Hopefully this will help keep our buildbot and GitHub on speaking terms.

Change-Id: I77cfa2d9e9468f5d39fce0d35dbfc45fb6f94967
