### PR TITLE
fix(full): Sync all branches by default, required for linux repo.

### DIFF
--- a/full.xml
+++ b/full.xml
@@ -3,7 +3,6 @@
   <include name="_remotes.xml" />
   <default revision="refs/heads/master"
            remote="github"
-           sync-c="true"
            sync-j="4" />
   <notice>
 Your sources have been sync'd successfully.


### PR DESCRIPTION
The branching scheme in our linux git repo is a bit more complicated
than the average repository and "coreos/master" isn't currently pointing
at the latest code that the coreos-kernel ebuild is expecting. The
cros-wrokon eclass was fixed to not depend on coreos/master but the
manifest wasn't. Fetching all heads will prevent this mismatch from
forcing emerge to fall back to fetching the kernel git repo itself.

Due to silly code in 'repo' if sync-c can only be enabled, not disabled.
So when it is set to true in defaults it cannot be set to false on a
per-project basis. We don't have many branches anyway so just fetching
all heads globally isn't a big deal.

Change-Id: I5763080557c29cb4182e85cd31bc140d936ce325
