### PR TITLE
master: remove linux kernel git repo, no longer required

### DIFF
--- a/master.xml
+++ b/master.xml
@@ -87,11 +87,6 @@ Your sources have been sync'd successfully.
            name="coreos/vboot_reference"
            groups="minilayout" />
 
-  <project path="src/third_party/linux"
-           name="coreos/linux"
-           groups="minilayout"
-           revision="coreos/master" />
-
   <project path="src/third_party/coreos-buildbot"
            name="coreos/coreos-buildbot"
            groups="minilayout" />


### PR DESCRIPTION
Kernels are now built from tarballs, cloning the SDK should be much
faster now! :)

Change-Id: Ic6ce8910760ddbdd95637a3e70bc79385d0b82c5
