### PR TITLE
master: remove board-overlays

### DIFF
--- a/master.xml
+++ b/master.xml
@@ -26,9 +26,6 @@ Your sources have been sync'd successfully.
            name="chromiumos/platform/factory-utils"
            groups="minilayout" remote="cros" />
 
-  <project path="src/overlays"
-           name="coreos/board-overlays"
-           groups="minilayout" />
   <project path="src/scripts" name="coreos/scripts"
            groups="minilayout" />
 


### PR DESCRIPTION
Long unused, finalize the deprecation of the old board-overlays system.

Change-Id: I14cce7118c8f1938d95351f7b03ddd19a8852560