### PR TITLE
Revert "build-1185: branch update_engine"

### DIFF
--- a/build-1185.xml
+++ b/build-1185.xml
@@ -47,7 +47,7 @@
   <project groups="minilayout" name="coreos/sysroot-wrappers" path="src/third_party/sysroot-wrappers" revision="437a7a86a482348828423ffd016b379fb70b0445" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/systemd" path="src/third_party/systemd" revision="e859aa9e993453be321450148d45d08fcc55c3f5" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/toolbox" path="src/third_party/toolbox" revision="3c71a4056e0724e77e047f84aab54109f595ae2b" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="coreos/update_engine" path="src/third_party/update_engine" revision="refs/heads/release-0.3"/>
+  <project groups="minilayout" name="coreos/update_engine" path="src/third_party/update_engine" revision="076636ee24dfb9789b61a571ba3431118773c82c" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/updateservicectl" path="src/third_party/updateservicectl" revision="bc01d1e95ec78540465f778280d31582b7baf866" upstream="refs/heads/master"/>
   
   <repo-hooks enabled-list="pre-upload" in-project="chromiumos/repohooks"/>

--- a/default.xml
+++ b/default.xml
@@ -1,1 +1,1 @@
-build-1185.xml
+master.xml


### PR DESCRIPTION
Reverts coreos/manifest#113

Mixed up master and build-1185 