### PR TITLE
build-1298: branch scripts and portage-stable

### DIFF
--- a/build-1298.xml
+++ b/build-1298.xml
@@ -38,9 +38,9 @@
   <project groups="minilayout" name="coreos/mantle" path="src/third_party/mantle" revision="fef810ff4b68e39d8439cb794732a52ee812b937" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/mayday" path="src/third_party/mayday" revision="5e2b4bcb0743ff0105cd193a8d9e4ddc78088153" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/nss-altfiles" path="src/third_party/nss-altfiles" revision="42bec47544ad80d3e39342b11ea33da05ff9133d" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="coreos/portage-stable" path="src/third_party/portage-stable" revision="fb5b67efc59f7822b9eb99b9ba5c4b927f6a221f" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="coreos/portage-stable" path="src/third_party/portage-stable" revision="refs/heads/build-1298"/>
   <project groups="minilayout" name="coreos/rkt" path="src/third_party/rkt" revision="535596b77567093f8f031d28b82a6d205c29664c" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="coreos/scripts" path="src/scripts" revision="60ef04a6a06c476ddfa23a3f7f72bf8feb4badd9" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="coreos/scripts" path="src/scripts" revision="refs/heads/build-1298"/>
   <project groups="minilayout" name="coreos/sdnotify-proxy" path="src/third_party/sdnotify-proxy" revision="bfd0269267d91f3bbe89db49ec8ea8903ae8aa3c" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/seismograph" path="src/third_party/seismograph" revision="b9c0e7cf7d49881c5214c97dd42d1b56c6f308ef" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/shim" path="src/third_party/shim" revision="03a1513b0985fd682b13a8d29fe3f1314a704c66" upstream="refs/heads/master"/>


### PR DESCRIPTION
Overlay was already branched, these two weren't yet

Change-Id: I4e53027f5febf15822ee834f67dedd54158ab0b2