### PR TITLE
Revert "master: Drop Docker"

### DIFF
--- a/master.xml
+++ b/master.xml
@@ -61,6 +61,10 @@ Your sources have been sync'd successfully.
            name="coreos/fleet"
            groups="minilayout" />
 
+  <project path="src/third_party/docker"
+           name="coreos/docker"
+           groups="minilayout" />
+
   <project path="src/third_party/etcdctl"
            name="coreos/etcdctl"
            groups="minilayout" />


### PR DESCRIPTION
This reverts commit 1802ef60d06e0ce4005714763cd11955e51d2b36.

We're now shipping 1.12.6 again on master, CROS_WORKON_COMMIT and all.

cc @dm0- 