### PR TITLE
master: drop chromium fork of pyelftools

### DIFF
--- a/master.xml
+++ b/master.xml
@@ -16,10 +16,6 @@ Your sources have been sync'd successfully.
     <copyfile src="AUTHORS" dest="AUTHORS" />
     <copyfile src="LICENSE" dest="LICENSE" />
   </project>
-  <project path="chromite/third_party/pyelftools"
-           groups="minilayout" remote="cros"
-           name="chromiumos/third_party/pyelftools" />
-
   <project path="src/scripts" name="coreos/scripts"
            groups="minilayout" />
 


### PR DESCRIPTION
I can't find anywhere we use this. The fork is also dead (last commit
four years ago). The only thing that could use it would be pax-utils but
we don't have the python use flag, so it doesn't need it. We should use
gentoo's (up to date) upstream version if we do still want it.