### PR TITLE
master: add coreos-cryptagent

### DIFF
--- a/master.xml
+++ b/master.xml
@@ -150,4 +150,8 @@ Your sources have been sync'd successfully.
            name="coreos/update-ssh-keys"
            groups="minilayout" />
 
+  <project path="src/third_party/coreos-cryptagent"
+           name="coreos/coreos-cryptagent"
+           groups="minilayout" />
+
 </manifest>


### PR DESCRIPTION
https://github.com/coreos/coreos-cryptagent will host the initramfs LUKS unlocking codebase.