### PR TITLE
Drop some unused git clones

### DIFF
--- a/master.xml
+++ b/master.xml
@@ -35,16 +35,8 @@ Your sources have been sync'd successfully.
            name="coreos/bootengine"
            groups="minilayout" />
 
-  <project path="src/third_party/etcd"
-           name="coreos/etcd"
-           groups="minilayout" />
-
   <project path="src/third_party/docker"
            name="coreos/docker"
-           groups="minilayout" />
-
-  <project path="src/third_party/etcdctl"
-           name="coreos/etcdctl"
            groups="minilayout" />
 
   <project path="src/third_party/seismograph"

--- a/master.xml
+++ b/master.xml
@@ -43,10 +43,6 @@ Your sources have been sync'd successfully.
            name="coreos/seismograph"
            groups="minilayout" />
 
-  <project path="src/third_party/sysroot-wrappers"
-           name="coreos/sysroot-wrappers"
-           groups="minilayout" />
-
   <project path="src/third_party/nss-altfiles"
            name="coreos/nss-altfiles"
            groups="minilayout" />

--- a/master.xml
+++ b/master.xml
@@ -84,7 +84,7 @@ Your sources have been sync'd successfully.
            groups="minilayout" />
 
   <project path="src/third_party/rkt"
-           name="coreos/rkt"
+           name="rkt/rkt"
            groups="minilayout" />
 
   <project path="src/third_party/systemd"


### PR DESCRIPTION
The `rkt` update will require developers to run `repo sync --force-sync`.  There is not a technical need for it; this is just so we're using the new GitHub organization consistently.  I can drop that commit if that's disruptive.