### PR TITLE
Drop unused repos in beta

### DIFF
--- a/build-2079.xml
+++ b/build-2079.xml
@@ -24,7 +24,6 @@
   <project groups="minilayout" name="coreos/mayday" path="src/third_party/mayday" revision="78318a5760bea08ff5a76779a070c2c8fbea2939" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/nss-altfiles" path="src/third_party/nss-altfiles" revision="42bec47544ad80d3e39342b11ea33da05ff9133d" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/portage-stable" path="src/third_party/portage-stable" revision="refs/heads/build-2079"/>
-  <project groups="minilayout" name="coreos/rkt" path="src/third_party/rkt" revision="0c8765619cae3391a9ffa12c8dbd12ba7a475eb8" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/scripts" path="src/scripts" revision="refs/heads/build-2079"/>
   <project groups="minilayout" name="coreos/sdnotify-proxy" path="src/third_party/sdnotify-proxy" revision="0f8ef1aa86c59fc6d54eadaffb248feaccd1018b" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/seismograph" path="src/third_party/seismograph" revision="a1279931829306af9b8ba37486ab23d6f0cd1488" upstream="refs/heads/master"/>
@@ -36,4 +35,5 @@
   <project groups="minilayout" name="coreos/update-ssh-keys" path="src/third_party/update-ssh-keys" revision="6cae3db342b57cb9f761f633a38443ed7aa9c153" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/update_engine" path="src/third_party/update_engine" revision="47dfb956377b748d2c5ab0a0e49218b79b29c2bf" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/updateservicectl" path="src/third_party/updateservicectl" revision="cf2a962b5a44760365788ce8621a7057be7d6cc2" upstream="refs/heads/master"/>
+  <project groups="minilayout" name="rkt/rkt" path="src/third_party/rkt" revision="0c8765619cae3391a9ffa12c8dbd12ba7a475eb8" upstream="refs/heads/master"/>
 </manifest>

--- a/build-2079.xml
+++ b/build-2079.xml
@@ -15,8 +15,6 @@
   <project groups="minilayout" name="coreos/coreos-overlay" path="src/third_party/coreos-overlay" revision="refs/heads/build-2079"/>
   <project groups="minilayout" name="coreos/dev-util" path="src/platform/dev" revision="1cb32a9414c6c6085519657dccaff18fe2a51dd7" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/docker" path="src/third_party/docker" revision="867a5999cefccefb3e0fb79ffa22f01dd7c1a5e1" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="coreos/etcd" path="src/third_party/etcd" revision="6da17cda18307eff6e946c824fb7b64ecaf34fbe" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="coreos/etcdctl" path="src/third_party/etcdctl" revision="aef33400e68e4cf56baee4ac97ac46c3b2328c42" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/fero" path="src/third_party/fero" revision="d69131ee1016933cb6681beade227a4aa53a282e" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/grub" path="src/third_party/grub" revision="0863c013179c5addee289fb4037e6df39ca4e351" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/ignition" path="src/third_party/ignition" revision="8c69134a2907c87ae53c6878da123d8f035f81f8" upstream="refs/heads/master"/>

--- a/build-2079.xml
+++ b/build-2079.xml
@@ -28,7 +28,6 @@
   <project groups="minilayout" name="coreos/sdnotify-proxy" path="src/third_party/sdnotify-proxy" revision="0f8ef1aa86c59fc6d54eadaffb248feaccd1018b" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/seismograph" path="src/third_party/seismograph" revision="a1279931829306af9b8ba37486ab23d6f0cd1488" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/shim" path="src/third_party/shim" revision="03a1513b0985fd682b13a8d29fe3f1314a704c66" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="coreos/sysroot-wrappers" path="src/third_party/sysroot-wrappers" revision="437a7a86a482348828423ffd016b379fb70b0445" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/systemd" path="src/third_party/systemd" revision="e62a7fea757f259eb330da5b6d3ab4ede46400a2" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/toolbox" path="src/third_party/toolbox" revision="586dcee184afe5f9d4a5b27478132e7b0f7d1173" upstream="refs/heads/master"/>
   <project groups="minilayout" name="coreos/torcx" path="src/third_party/torcx" revision="cc496431717d92cccd478740a37f31050e8347fd" upstream="refs/heads/master"/>

--- a/master.xml
+++ b/master.xml
@@ -35,16 +35,8 @@ Your sources have been sync'd successfully.
            name="coreos/bootengine"
            groups="minilayout" />
 
-  <project path="src/third_party/etcd"
-           name="coreos/etcd"
-           groups="minilayout" />
-
   <project path="src/third_party/docker"
            name="coreos/docker"
-           groups="minilayout" />
-
-  <project path="src/third_party/etcdctl"
-           name="coreos/etcdctl"
            groups="minilayout" />
 
   <project path="src/third_party/seismograph"

--- a/master.xml
+++ b/master.xml
@@ -43,10 +43,6 @@ Your sources have been sync'd successfully.
            name="coreos/seismograph"
            groups="minilayout" />
 
-  <project path="src/third_party/sysroot-wrappers"
-           name="coreos/sysroot-wrappers"
-           groups="minilayout" />
-
   <project path="src/third_party/nss-altfiles"
            name="coreos/nss-altfiles"
            groups="minilayout" />

--- a/master.xml
+++ b/master.xml
@@ -84,7 +84,7 @@ Your sources have been sync'd successfully.
            groups="minilayout" />
 
   <project path="src/third_party/rkt"
-           name="coreos/rkt"
+           name="rkt/rkt"
            groups="minilayout" />
 
   <project path="src/third_party/systemd"


### PR DESCRIPTION
This will prevent the person tagging CL releases for multiple channels from having to remember `--force-sync` for the next two months.  (Only the rkt change is necessary for this, but I'm taking the whole cleanup PR so the other channels don't clone extra Git repos, too.)

Backports #164